### PR TITLE
Fixes build error in Xcode 10 beta 4

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -764,6 +764,7 @@
 		B299FF1D1F22C338004A2CB9 /* ADURLExtensionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADURLExtensionsTest.m; sourceTree = "<group>"; };
 		B29CD3971EC1196C001791CC /* ADRegistrationInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADRegistrationInformation.m; sourceTree = "<group>"; };
 		B2B7850F1F733C1E00B776BD /* NSStringTelemetryExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringTelemetryExtensionsTests.m; sourceTree = "<group>"; };
+		C53DCEB92104007E009A848A /* ADAL-core.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADAL-core.pch"; sourceTree = "<group>"; };
 		D60B65371F355C5700A89487 /* ADAuthorityValidationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAuthorityValidationRequest.h; sourceTree = "<group>"; };
 		D60B65381F355C5700A89487 /* ADAuthorityValidationRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthorityValidationRequest.m; sourceTree = "<group>"; };
 		D622564F1F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestAuthorityValidationResponse.h; sourceTree = "<group>"; };
@@ -1034,6 +1035,7 @@
 				9453C3A41C583AA8006B9E79 /* public */,
 				60C351B91DA0D588006C8435 /* ADAL.m */,
 				D67D3D401F38542700660F32 /* ADAL.pch */,
+				C53DCEB92104007E009A848A /* ADAL-core.pch */,
 				9453C3A31C583A9C006B9E79 /* ADAL_Internal.h */,
 				8BB8345B18074A58007F9F0D /* ADAuthenticationContext.m */,
 				D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */,
@@ -3089,7 +3091,7 @@
 				DSTROOT = /usr/local/lib;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = "src/ADAL-core.pch";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -3114,7 +3116,7 @@
 				DSTROOT = /usr/local/lib;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = "src/ADAL-core.pch";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/ADAL/src/ADAL-core.pch
+++ b/ADAL/src/ADAL-core.pch
@@ -1,0 +1,84 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IPHONE
+#import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
+#endif
+
+#import "ADAL_Internal.h"
+
+#ifndef DebugLog
+#ifdef DEBUG
+#   define DebugLog(fmt, ...) NSLog((@"%s[%d][%@] " fmt), __PRETTY_FUNCTION__, __LINE__, [[NSThread currentThread] isEqual:[NSThread mainThread]] ? @"main" : @"work", ##__VA_ARGS__);
+#else
+#   define DebugLog(...)
+#endif
+#endif
+
+#if __has_include("../../../aad_overrides.h")
+#include "../../../aad_overrides.h"
+#endif
+
+
+#if !defined(__clang__) || __clang_major__ < 3
+#   ifndef __bridge
+#       define __bridge
+#   endif
+
+#   ifndef __bridge_retain
+#       define __bridge_retain
+#   endif
+
+#   ifndef __bridge_retained
+#       define __bridge_retained
+#   endif
+
+#   ifndef __bridge_transfer
+#       define __bridge_transfer
+#   endif
+
+#   ifndef __autoreleasing
+#       define __autoreleasing
+#   endif
+
+#   ifndef __strong
+#       define __strong
+#   endif
+
+#   ifndef __unsafe_unretained
+#       define __unsafe_unretained
+#   endif
+
+#   ifndef __weak
+#       define __weak
+#   endif
+#endif
+
+#endif


### PR DESCRIPTION
In Xcode 10 beta 4, building once works, but after that I get the following error. This commit fixes it.

(The build error is an Xcode problem from all I can research, but this workaround helps in the short term until Apple fixes whatever the underlying issue is)

```
Showing All Messages
:-1: Cycle in dependencies between targets 'ADAL' and 'ADAL-core'; building could produce unreliable results.
Cycle path: ADAL → ADAL-core → ADAL
Cycle details:
→ Target 'ADAL' has a command with output '/Users/adamwulf/Library/Developer/Xcode/DerivedData/Fantastical-gnicuerpgusmjygxqzzgbokxbifw/Build/Products/Debug-iphonesimulator/ADAL.framework/ADAL'
○ Target 'ADAL' has target dependency on Target 'ADAL-core'
→ Target 'ADAL-core' has compile command with input '/Users/adamwulf/Documents/Code/fantastical/src/Contributed/azure-activedirectory-library-for-objc/ADAL/src/utils/ADALFrameworkUtils.m'
○ Target 'ADAL-core' has process command with input '/Users/adamwulf/Documents/Code/fantastical/src/Contributed/azure-activedirectory-library-for-objc/ADAL/src/ADAL.pch'
→ Target 'ADAL' has write command with output /Users/adamwulf/Library/Developer/Xcode/DerivedData/Fantastical-gnicuerpgusmjygxqzzgbokxbifw/Build/Intermediates.noindex/ADAL.build/Debug-iphonesimulator/ADAL.build/module.modulemap
```